### PR TITLE
ログイン時にログインボタンを表示しない。サーバーコンポーネントとクライアントコンポーネントを区別。

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import LoginButton from '@/components/LoginButton';
-import { Button } from '../components/ui/button';
 import Link from 'next/link';
+import { Button } from '../components/ui/button';
 
 export default async function Home() {
   return (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,13 +1,8 @@
-'use client';
-import React from 'react';
-import Login from './Login';
-import Logout from '../components/Logout';
-import { useSession } from 'next-auth/react';
-import Link from 'next/link';
 import Image from 'next/image';
+import Link from 'next/link';
+import HeaderLoginButton from './HeaderLoginButton';
 
 const Header = () => {
-  const { data: session, status } = useSession();
   return (
     <header>
       <div className="flex justify-between px-8 pt-4 items-center">
@@ -20,20 +15,7 @@ const Header = () => {
           <Link href="/questions">
             <p>問題一覧</p>
           </Link>
-          {status === 'authenticated' ? (
-            <div className="flex gap-6">
-              <Logout />
-              <Image
-                src={session.user?.image ?? ``}
-                alt="Googleアイコン"
-                width={40}
-                height={40}
-                style={{ borderRadius: '50px' }}
-              />
-            </div>
-          ) : (
-            <Login />
-          )}
+          <HeaderLoginButton />
         </div>
       </div>
     </header>

--- a/components/HeaderLoginButton.tsx
+++ b/components/HeaderLoginButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { signIn, useSession } from 'next-auth/react';
+import Image from 'next/image'; // Imageコンポーネントのインポート
+import Logout from './Logout'; // Logoutコンポーネントのインポート
+import { Button } from './ui/button';
+
+const HeaderLoginButton = () => {
+  const { data: session, status } = useSession();
+
+  if (status === 'authenticated') {
+    return (
+      <div className="flex gap-6">
+        <Logout /> {/* Logoutボタンを表示 */}
+        <Image
+          src={session?.user?.image ?? ``} // セッションデータの画像を表示
+          alt="Googleアイコン"
+          width={40}
+          height={40}
+          style={{ borderRadius: '50px' }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Button onClick={() => signIn('google', {}, { prompt: 'login' })}>
+        ログイン
+      </Button>
+    </div>
+  );
+};
+
+export default HeaderLoginButton;

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -8,12 +8,9 @@ export default function Login() {
     return <div>Loading...</div>;
   }
 
-  if (status !== 'authenticated') {
     return (
       <div>
         <LoginButton />
       </div>
     );
-  }
-  return null;
 }

--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -1,8 +1,14 @@
 'use client';
-import { signIn } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
 import { Button } from './ui/button';
 
 const LoginButton = () => {
+  const { data: session, status } = useSession();
+
+  if (status === 'authenticated') {
+    return null;
+  }
+
   return (
     <div>
       <Button onClick={() => signIn('google', {}, { prompt: 'login' })}>ログイン</Button>


### PR DESCRIPTION
## Issue
close #22 

## 学び
ヘッダー全体がクライアントコンポーネントになっていたところを、ボタン部分のみをクライアントコンポーネントとして切り出して、他をサーバーコンポーネントに変更したら、表示速度がめちゃ早くなった。